### PR TITLE
[FEATURE] Migrate @stacks/transactions and @stacks/network from v6 to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@stacks/transactions": "^6.13.0",
-    "@stacks/network": "^6.13.0",
+    "@stacks/transactions": "^7.3.1",
+    "@stacks/network": "^7.3.1",
     "axios": "^1.6.0"
   },
   "devDependencies": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,6 @@
  * x402-stacks - Type definitions for x402 payment protocol on Stacks blockchain
  */
 
-import { StacksNetwork } from '@stacks/network';
-
 /**
  * Network type for Stacks blockchain
  */
@@ -75,7 +73,7 @@ export interface PaymentDetails {
   senderKey: string;
 
   /** Network to use */
-  network: NetworkType | StacksNetwork;
+  network: NetworkType;
 
   /** Optional memo */
   memo?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,8 +3,8 @@
  * Helper functions for working with x402 payments on Stacks
  */
 
-import { makeRandomPrivKey, getPublicKey, publicKeyToAddress, AddressVersion } from '@stacks/transactions';
-import { StacksMainnet, StacksTestnet } from '@stacks/network';
+import { randomPrivateKey, privateKeyToPublic, publicKeyToAddress, AddressVersion } from '@stacks/transactions';
+import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
 import { NetworkType, TokenType, TokenContract } from './types';
 
 /**
@@ -59,8 +59,8 @@ export function microUSDCxToUSDCx(microUSDCx: bigint | string): string {
  * Generate a random Stacks keypair
  */
 export function generateKeypair(network: NetworkType = 'testnet') {
-  const privateKey = makeRandomPrivKey();
-  const publicKey = getPublicKey(privateKey);
+  const privateKey = randomPrivateKey();
+  const publicKey = privateKeyToPublic(privateKey);
 
   const addressVersion = network === 'mainnet'
     ? AddressVersion.MainnetSingleSig
@@ -69,8 +69,8 @@ export function generateKeypair(network: NetworkType = 'testnet') {
   const address = publicKeyToAddress(addressVersion, publicKey);
 
   return {
-    privateKey: Buffer.from(privateKey.data).toString('hex'),
-    publicKey: Buffer.from(publicKey.data).toString('hex'),
+    privateKey,
+    publicKey,
     address,
   };
 }
@@ -286,7 +286,7 @@ export function truncateAddress(address: string, chars: number = 6): string {
  * Get network instance from network type
  */
 export function getNetworkInstance(network: NetworkType) {
-  return network === 'mainnet' ? new StacksMainnet() : new StacksTestnet();
+  return network === 'mainnet' ? STACKS_MAINNET : STACKS_TESTNET;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Upgrades `@stacks/transactions` and `@stacks/network` from `^6.13.0` to `^7.3.1`
- Replaces deprecated v6 class constructors, enums, and serialization patterns with v7 equivalents
- Simplifies network handling by removing `StacksNetwork` type in favor of `'mainnet' | 'testnet'` string literals throughout

Closes #2

## Changes by file

| File | Changes |
|------|---------|
| `package.json` | Dependency version bumps |
| `src/types.ts` | Remove `StacksNetwork` import; narrow `PaymentDetails.network` to `NetworkType` |
| `src/utils.ts` | `randomPrivateKey`/`privateKeyToPublic`, `STACKS_MAINNET`/`STACKS_TESTNET` constants |
| `src/interceptor.ts` | Remove `AnchorMode`, `PostConditionMode`, `TransactionVersion` enums; string network params; `serialize()` returns hex directly |
| `src/client.ts` | Same enum removals; `broadcastTransaction({ transaction, network })` object signature; remove `instanceof` checks; `getNetwork()` returns `NetworkType` |

## Test plan

- [x] `npm run build` compiles cleanly with zero TypeScript errors
- [x] Grep confirms zero remaining v6 patterns (`StacksMainnet` class, `AnchorMode`, `Buffer.from.*serialize`, `makeRandomPrivKey`, `TransactionVersion`, `instanceof Stacks`)
- [ ] Manual integration test with testnet STX transfer
- [ ] Manual integration test with testnet sBTC transfer
- [ ] Manual integration test with testnet USDCx transfer

🤖 Generated with [Claude Code](https://claude.com/claude-code)