### PR TITLE
fix: increase verifier settlement timeout from 30s to 120s

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export {
   X402PaymentVerifierV2,
   createVerifierV2,
 } from './verifier-v2';
-export type { VerifyOptionsV2, SettleOptionsV2 } from './verifier-v2';
+export type { VerifyOptionsV2, SettleOptionsV2, X402PaymentVerifierConfig } from './verifier-v2';
 
 // Middleware
 export {

--- a/src/verifier-v2.ts
+++ b/src/verifier-v2.ts
@@ -33,6 +33,15 @@ export interface SettleOptions {
 }
 
 /**
+ * Configuration options for X402PaymentVerifier
+ */
+export interface X402PaymentVerifierConfig {
+  /** HTTP timeout in milliseconds (default: 120000). Settlement operations
+   *  can take 60+ seconds for contract call confirmations (sBTC, USDCx). */
+  timeout?: number;
+}
+
+/**
  * Payment verifier for validating x402 payments on Stacks
  * Compatible with Coinbase x402 protocol
  */
@@ -40,11 +49,11 @@ export class X402PaymentVerifier {
   private facilitatorUrl: string;
   private httpClient: AxiosInstance;
 
-  constructor(facilitatorUrl: string = 'http://localhost:8085') {
+  constructor(facilitatorUrl: string = 'http://localhost:8085', config?: X402PaymentVerifierConfig) {
     this.facilitatorUrl = facilitatorUrl.replace(/\/$/, ''); // Remove trailing slash
 
     this.httpClient = axios.create({
-      timeout: 30000, // V2 may need longer timeout for settlement
+      timeout: config?.timeout ?? 120000, // 2 minutes — settlement needs time for block confirmation
       headers: {
         'Content-Type': 'application/json',
       },
@@ -228,8 +237,8 @@ export class X402PaymentVerifier {
 /**
  * Create a verifier instance
  */
-export function createVerifier(facilitatorUrl?: string): X402PaymentVerifier {
-  return new X402PaymentVerifier(facilitatorUrl);
+export function createVerifier(facilitatorUrl?: string, config?: X402PaymentVerifierConfig): X402PaymentVerifier {
+  return new X402PaymentVerifier(facilitatorUrl, config);
 }
 
 // ===== Backward Compatibility Aliases =====

--- a/src/verifier-v2.ts
+++ b/src/verifier-v2.ts
@@ -36,8 +36,7 @@ export interface SettleOptions {
  * Configuration options for X402PaymentVerifier
  */
 export interface X402PaymentVerifierConfig {
-  /** HTTP timeout in milliseconds (default: 120000). Settlement operations
-   *  can take 60+ seconds for contract call confirmations (sBTC, USDCx). */
+  /** HTTP timeout in milliseconds (default: 120000) */
   timeout?: number;
 }
 
@@ -53,7 +52,7 @@ export class X402PaymentVerifier {
     this.facilitatorUrl = facilitatorUrl.replace(/\/$/, ''); // Remove trailing slash
 
     this.httpClient = axios.create({
-      timeout: config?.timeout ?? 120000, // 2 minutes — settlement needs time for block confirmation
+      timeout: config?.timeout ?? 120000,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -54,7 +54,7 @@ export class X402PaymentVerifierV1 {
     this.network = network;
 
     this.httpClient = axios.create({
-      timeout: 15000,
+      timeout: 120000, // 2 minutes — settlement needs time for block confirmation
       headers: {
         'Content-Type': 'application/json',
       },


### PR DESCRIPTION
## Summary

- Increases V2 verifier HTTP timeout from 30s to 120s (2 minutes)
- Increases V1 verifier HTTP timeout from 15s to 120s (2 minutes)
- Adds `X402PaymentVerifierConfig` interface for custom timeout configuration
- Exports the config type from the main package entry point

## Problem

sBTC (and USDCx) contract call settlements fail because:

1. The facilitator uses 15 retries x 2s = 30s for block confirmation, plus broadcast time (~1-3s)
2. SIP-010 `transfer` contract calls take longer than native STX transfers
3. The SDK's 30s HTTP timeout expires before the facilitator finishes confirming

This causes a cascade: timeout -> error -> server returns 402 again -> client's retry guard blocks -> "Payment retry limit exceeded"

STX payments work because native transfers confirm faster.

## Evidence

- stx402.com already hit this and patched it with \`patch-package\` (15s -> 120s for v1)
- x402.biwas.xyz and x402.aibtc.com also use default timeout and are affected for sBTC
- aibtc.com inbox sBTC payments fail consistently with this timeout

## Changes

| File | Change |
|------|--------|
| \`src/verifier-v2.ts\` | Added \`X402PaymentVerifierConfig\` interface, constructor accepts optional config, default timeout 120s |
| \`src/verifier.ts\` | Increased v1 timeout from 15s to 120s |
| \`src/index.ts\` | Export \`X402PaymentVerifierConfig\` type |

## Usage

\`\`\`typescript
// Default (120s timeout)
const verifier = new X402PaymentVerifier(facilitatorUrl);

// Custom timeout
const verifier = new X402PaymentVerifier(facilitatorUrl, { timeout: 180000 });
\`\`\`

## Test plan

- [ ] Verify STX payments still work (no regression)
- [ ] Verify sBTC payments through aibtc.com inbox
- [ ] Verify sBTC payments through x402 API endpoints

Fixes #5

Generated with [Claude Code](https://claude.com/claude-code)